### PR TITLE
Update tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+sudo: false
+python:
+  - "2.7"
+env:
+  - TOXENV=py26-1.3.X
+  - TOXENV=py26-1.4.X
+  - TOXENV=py26-1.5.X
+  - TOXENV=py26-1.6.X
+  - TOXENV=py27-1.3.X
+  - TOXENV=py27-1.4.X
+  - TOXENV=py27-1.5.X
+  - TOXENV=py27-1.6.X
+  - TOXENV=py27-1.7.X
+  - TOXENV=py27-1.8.X
+  - TOXENV=py33-1.5.X
+  - TOXENV=py33-1.6.X
+  - TOXENV=py33-1.7.X
+  - TOXENV=py33-1.8.X
+  - TOXENV=py34-1.7.X
+  - TOXENV=py34-1.8.X
+  - TOXENV=docs
+install:
+  - pip install -q --use-mirrors tox
+script:
+  - tox

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 django-comps
 ==========================
 
+[![Build Status][master-build-image]][travis-ci]
+
+[travis-ci]: https://travis-ci.org/caktus/django-comps/
+[master-build-image]: https://travis-ci.org/caktus/django-comps.svg?branch=master
+
 An app that facilitates rapid prototyping.
 
 Provides an entry point for deeper integration of front end designers with

--- a/comps/tests/urls.py
+++ b/comps/tests/urls.py
@@ -3,10 +3,10 @@ from __future__ import unicode_literals
 from django.http import HttpResponseNotFound, HttpResponseServerError
 try:
     # Django 1.4+
-    from django.conf.urls import include, patterns, url, handler404, handler500
+    from django.conf.urls import include, url, handler404, handler500
 except ImportError: # pragma: no cover
     # Django 1.3
-    from django.conf.urls.defaults import include, patterns, url, handler404, handler500
+    from django.conf.urls.defaults import include, url, handler404, handler500
 
 
 handler404 = 'comps.tests.urls.test_404'
@@ -21,6 +21,6 @@ def test_500(request):
     return HttpResponseServerError()
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^comps/', include('comps.urls')),
-)
+]

--- a/comps/urls.py
+++ b/comps/urls.py
@@ -1,18 +1,20 @@
 try:
     # Django 1.4+
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError: # pragma: no cover
     # Django 1.3
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
+from comps import views
 
-urlpatterns = patterns('comps.views',
+
+urlpatterns = [
     url(r'^comps(?:/(?P<directory_slug>[\w\-]+))?/$',
-        'comp_listing',
+        views.comp_listing,
         name='comp-listing'),
     url(r'^comps(?:/(?P<directory_slug>[\w\-]+))?/(?P<slug>[\w.\-]+)$',
-        'comp',
+        views.comp,
         name='comp'),
     url(r'^export-comps/$',
-        'export_comps',
+        views.export_comps,
         name='export-comps'),
-)
+]

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -34,7 +34,7 @@ You should include the comps urls in your root url patterns.
 .. code-block:: python
 
     if 'comps' in settings.INSTALLED_APPS:
-        urlpatterns += patterns('', url(r'^', include('comps.urls')))
+        urlpatterns += [url(r'^', include('comps.urls'))]
 
 That should be enough to get you up and running with django-comps.
 

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,5 +1,6 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
-urlpatterns = patterns('',
+
+urlpatterns = [
     url(r'^', include('comps.urls'))
-)
+]

--- a/runtests.py
+++ b/runtests.py
@@ -19,6 +19,10 @@ if not settings.configured:
             'django.contrib.sessions',
             'comps',
         ),
+        MIDDLEWARE_CLASSES=(
+            'django.middleware.common.CommonMiddleware',
+            'django.middleware.csrf.CsrfViewMiddleware',
+        ),
         SITE_ID=1,
         SECRET_KEY='super-secret',
         STATIC_ROOT=mkdtemp(prefix="test-django-comps-"),

--- a/runtests.py
+++ b/runtests.py
@@ -41,4 +41,9 @@ def runtests():
 
 
 if __name__ == '__main__':
+    import django
+    try:
+        django.setup()
+    except:  # < Django 1.7
+        pass
     runtests()

--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 import sys
+from tempfile import mkdtemp
 
 from django.conf import settings
+
 
 if not settings.configured:
     settings.configure(
@@ -19,6 +21,7 @@ if not settings.configured:
         ),
         SITE_ID=1,
         SECRET_KEY='super-secret',
+        STATIC_ROOT=mkdtemp(prefix="test-django-comps-"),
         TEMPLATE_CONTEXT_PROCESSORS=(
             'django.contrib.auth.context_processors.auth',
             'django.core.context_processors.request',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 downloadcache = {toxworkdir}/_download/
 envlist =
-    py26-{1.3.X,1.4.X},
-    py27-{1.3.X,1.4.X,1.5.X,1.6.X},
+    py26-{1.3.X,1.4.X,1.5.X,1.6.X},
+    py27-{1.3.X,1.4.X,1.5.X,1.6.X,1.7.X,1.8.X},
     py33-{1.5.X,1.6.X},
     docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ downloadcache = {toxworkdir}/_download/
 envlist =
     py26-{1.3.X,1.4.X,1.5.X,1.6.X},
     py27-{1.3.X,1.4.X,1.5.X,1.6.X,1.7.X,1.8.X},
-    py33-{1.5.X,1.6.X},
+    py33-{1.5.X,1.6.X,1.7.X,1.8.X},
+    py34-{1.7.X,1.8.X},
     docs
 
 [testenv]
@@ -13,6 +14,8 @@ deps =
     1.4.X: Django>=1.4.0,<1.5
     1.5.X: Django>=1.5.0,<1.6
     1.6.X: Django>=1.6.0,<1.7
+    1.7.X: Django>=1.7.0,<1.8
+    1.8.X: Django>=1.8.0,<1.9
 
 [testenv:docs]
 basepython = python2.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,42 +1,18 @@
 [tox]
 downloadcache = {toxworkdir}/_download/
 envlist =
-    py33-1.6.X,py33-1.5.X,py26-1.4.X,py26-1.3.X,py27-1.6.X,py27-1.5.X,py27-1.4.X,py27-1.3.X,docs
+    py26-{1.3.X,1.4.X},
+    py27-{1.3.X,1.4.X,1.5.X,1.6.X},
+    py33-{1.5.X,1.6.X},
+    docs
 
 [testenv]
 commands = {envpython} runtests.py
-
-[testenv:py33-1.6.X]
-basepython = python3.3
-deps = django>=1.6,<1.7
-
-[testenv:py33-1.5.X]
-basepython = python3.3
-deps = django>=1.5,<1.6
-
-[testenv:py26-1.4.X]
-basepython = python2.6
-deps = django>=1.4,<1.5
-
-[testenv:py26-1.3.X]
-basepython = python2.6
-deps = django>=1.3,<1.4
-
-[testenv:py27-1.6.X]
-basepython = python2.7
-deps = django>=1.6,<1.7
-
-[testenv:py27-1.5.X]
-basepython = python2.7
-deps = django>=1.5,<1.6
-
-[testenv:py27-1.4.X]
-basepython = python2.7
-deps = django>=1.4,<1.5
-
-[testenv:py27-1.3.X]
-basepython = python2.7
-deps = django>=1.3,<1.4
+deps =
+    1.3.X: Django>=1.3.0,<1.4
+    1.4.X: Django>=1.4.0,<1.5
+    1.5.X: Django>=1.5.0,<1.6
+    1.6.X: Django>=1.6.0,<1.7
 
 [testenv:docs]
 basepython = python2.6


### PR DESCRIPTION
* Test against all supported environments (Python 2.6+) for Django 1.3 to Django 1.8
* Run tests on Travis
* Fix tests on Django 1.6+ by specifying a temporary directory for `STATIC_ROOT`
* Fix tests on Django 1.7+ by calling `django.setup()` in `runtests.py`
* Fix warning on Django 1.7+ by specifying minimal values for `MIDDLEWARE_CLASSES`
* Fix deprecation warnings on Django 1.8 by removing use of `patterns()`